### PR TITLE
Add stack tracing to Crafter

### DIFF
--- a/pickaxe/crafter.py
+++ b/pickaxe/crafter.py
@@ -1,6 +1,15 @@
 import pickle
 import pickletools
+from typing import Any
 from .pickle_opcode import name_to_op, OpStr
+
+_STACK_ANY = name_to_op["BINGET"].stack_after[0]
+_STACK_MARK = name_to_op["MARK"].stack_after[0]
+_STACK_LIST = name_to_op["APPEND"].stack_after[0]
+_STACK_DICT = name_to_op["EMPTY_DICT"].stack_after[0]
+_STACK_TUPLE = name_to_op["TUPLE"].stack_after[0]
+_STACK_SET = name_to_op["EMPTY_SET"].stack_after[0]
+_STACK_FROZENSET = name_to_op["FROZENSET"].stack_after[0]
 
 
 class Crafter:
@@ -9,6 +18,9 @@ class Crafter:
             forbidden_bytes = []
 
         self._payload = b""
+        self._stack: list[Any] = []
+        self._memo: dict[int, Any] = {}
+        self._trace_state_valid = True
         self._has_explicit_stop = False
         self.forbidden_bytes = [b if isinstance(b, int) else b[0] for b in forbidden_bytes]
         self.check_stop = check_stop  # reserved and not implemented yet
@@ -18,10 +30,27 @@ class Crafter:
     def payload(self) -> bytes:
         return self._payload
 
+    @property
+    def stack(self) -> list[Any]:
+        return list(self._stack)
+
+    @property
+    def memo(self) -> dict[int, Any]:
+        return dict(self._memo)
+
+    @property
+    def stack_is_valid(self) -> bool:
+        return self._trace_state_valid
+
+    @property
+    def memo_is_valid(self) -> bool:
+        return self._trace_state_valid
+
 
     # self.payload += b の wrapperに過ぎないが、オーバーライドしてデバッグに使うといった用途を考えている
     def add_payload(self, b: bytes):
         self._append_payload(b)
+        self._invalidate_trace_state()
 
 
     def _append_payload(self, b: bytes, *, explicit_stop=False):
@@ -35,10 +64,21 @@ class Crafter:
     # shorten?
     # self.add_payload(pickle.<OP>) vs self.add_op("<OP>")
     def add_op(self, op_str: OpStr):
+        op = self._append_opcode(op_str)
+        if op.arg is not None:
+            self._invalidate_trace_state()
+            return
+        self._apply_opcode(op)
+
+
+    def _append_opcode(self, op_str: OpStr):
         op_str = op_str.upper()  # type: ignore
         if op_str not in name_to_op:
             raise ValueError(f"{op_str} is not a pickle opcode")
-        self._append_payload(name_to_op[op_str].code.encode("latin-1"), explicit_stop=op_str == "STOP")
+
+        op = name_to_op[op_str]
+        self._append_payload(op.code.encode("latin-1"), explicit_stop=op_str == "STOP")
+        return op
 
 
     def pop(self):
@@ -75,13 +115,14 @@ class Crafter:
         b = pickle.encode_long(n)
         length = len(b)
         if length < 256:
-            self.add_payload(pickle.LONG1)
+            self._append_opcode("LONG1")
             self._add_number1(length)
         else:
-            self.add_payload(pickle.LONG4)
+            self._append_opcode("LONG4")
             self._add_number4(length)
 
-        self.add_payload(b)
+        self._append_payload(b)
+        self._push_stack_value(n)
 
 
     def _push_small_number(self, n: int, check=False):
@@ -89,8 +130,9 @@ class Crafter:
             raise ValueError("small integer only")
         
         if n < 0 or 0xffff < n:
-            self.add_payload(pickle.BININT)
+            self._append_opcode("BININT")
             self._add_number_to_bytes(n, 4, signed=True)
+            self._push_stack_value(n)
             return
 
         if n < 0x100:
@@ -103,18 +145,21 @@ class Crafter:
 
 
     def _push_int1(self, n: int):
-        self.add_payload(pickle.BININT1)
+        self._append_opcode("BININT1")
         self._add_number1(n)
+        self._push_stack_value(n)
 
 
     def _push_int2(self, n: int):
-        self.add_payload(pickle.BININT2)
+        self._append_opcode("BININT2")
         self._add_number2(n)
+        self._push_stack_value(n)
 
 
     def _push_int4(self, n: int):
-        self.add_payload(pickle.BININT)
+        self._append_opcode("BININT")
         self._add_number4(n)
+        self._push_stack_value(n)
 
 
     def push_str(self, s: str):
@@ -122,22 +167,25 @@ class Crafter:
         length = len(data)
 
         if length < 0x100:
-            self.add_payload(pickle.SHORT_BINUNICODE)
+            self._append_opcode("SHORT_BINUNICODE")
             self._add_number1(length)
-            self.add_payload(data)
+            self._append_payload(data)
+            self._push_stack_value(s)
             return
         
         if length < 2**32:
-            self.add_payload(pickle.BINUNICODE)
+            self._append_opcode("BINUNICODE")
             self._add_number4(length)
-            self.add_payload(data)
+            self._append_payload(data)
+            self._push_stack_value(s)
             return
 
         # not tested
         if length < 2**64:
-            self.add_payload(pickle.BINUNICODE8)
-            self.add_payload(length.to_bytes(8, "little"))
-            self.add_payload(data)
+            self._append_opcode("BINUNICODE8")
+            self._append_payload(length.to_bytes(8, "little"))
+            self._append_payload(data)
+            self._push_stack_value(s)
             return
 
         raise ValueError(f"Too long string ({length} bytes)")
@@ -148,9 +196,10 @@ class Crafter:
         if l > 0xff:
             raise ValueError("byte-length must be shorter than 0x100")
 
-        self.add_op("SHORT_BINBYTES")
+        self._append_opcode("SHORT_BINBYTES")
         self._add_number1(l)
-        self.add_payload(b)
+        self._append_payload(b)
+        self._push_stack_value(b)
 
 
     def push_bytes(self, b: bytes):
@@ -158,20 +207,28 @@ class Crafter:
         if l < 0x100:
             self._push_short_bytes(b)
         else:
-            self.add_op("BINBYTES")
+            self._append_opcode("BINBYTES")
             self._add_number4(l)
-            self.add_payload(b)
+            self._append_payload(b)
+            self._push_stack_value(b)
 
 
     # utils about list, tuple and dict
 
     def tuple(self):
-        self.add_payload(pickle.TUPLE)
+        self.add_op("TUPLE")
 
 
     def to_tuple(self, cnt: int=0, use_mark: bool=False):
         if cnt in range(0, 4) and not use_mark:
-            self.add_payload(pickle._tuplesize2code[cnt])  # type: ignore
+            if cnt == 0:
+                self.add_op("EMPTY_TUPLE")
+            elif cnt == 1:
+                self.add_op("TUPLE1")
+            elif cnt == 2:
+                self.add_op("TUPLE2")
+            else:
+                self.add_op("TUPLE3")
         else:
             # todo: check whether MARK(@) is used in the payload
             self.tuple()
@@ -187,16 +244,17 @@ class Crafter:
         if use_stack:
             self.push_str(module)
             self.push_str(name)
-            self.add_payload(pickle.STACK_GLOBAL)
+            self.add_op("STACK_GLOBAL")
         else:
             # shorter than STACK_GLOBAL
             # if other optimization techniques are used (for example, memoize frequently used strings)
             # this method may not be effective
-            self.add_payload(pickle.GLOBAL)
-            self.add_payload(module.encode("utf-8"))
+            self._append_opcode("GLOBAL")
+            self._append_payload(module.encode("utf-8"))
             self._add_newline()
-            self.add_payload(name.encode("utf-8"))
+            self._append_payload(name.encode("utf-8"))
             self._add_newline()
+            self._push_stack_value(_STACK_ANY)
 
 
     def call_f(self, argc: int=0, use_mark=False):
@@ -205,26 +263,26 @@ class Crafter:
 
 
     def reduce(self):
-        self.add_payload(pickle.REDUCE)
+        self.add_op("REDUCE")
 
 
     # simple wrappers
 
     def stop(self):
-        self._append_payload(pickle.STOP, explicit_stop=True)
+        self.add_op("STOP")
 
 
     def mark(self):
-        self.add_payload(pickle.MARK)
+        self.add_op("MARK")
 
 
     def proto(self, proto=pickle.DEFAULT_PROTOCOL):
-        self.add_op("PROTO")
         if proto > 0xff:
             raise ValueError("The protocol number must be 1 byte")
         if proto < 0:
             raise ValueError("The protocol number must not be a negative number")
         
+        self._append_opcode("PROTO")
         self._add_number1(proto)
 
 
@@ -232,23 +290,22 @@ class Crafter:
     # todo: emulate memo and estimate index in memoize
 
     def memoize(self):
-        self.add_payload(pickle.MEMOIZE)
+        self.add_op("MEMOIZE")
 
 
     def get_memo(self, idx: int):
         if idx < 0x100:
-            self.add_payload(pickle.BINGET)
+            self._append_opcode("BINGET")
             self._add_number1(idx)
-            return
-
-        if idx < 2**32:
-            self.add_payload(pickle.LONG_BINGET)
+        elif idx < 2**32:
+            self._append_opcode("LONG_BINGET")
             self._add_number4(idx)
-            return
+        else:
+            self._append_opcode("GET")
+            self._add_number(idx)
+            self._add_newline()
 
-        self.add_payload(pickle.GET)
-        self._add_number(idx)
-        self._add_newline()
+        self._push_stack_value(self._memo.get(idx, _STACK_ANY))
 
 
     def put_memo(self, idx: int):
@@ -256,18 +313,24 @@ class Crafter:
             raise ValueError("index must not be negative")
         
         if idx < 0x100:
-            self.add_payload(pickle.BINPUT)
+            self._append_opcode("BINPUT")
             self._add_number1(idx)
-            return
-        
-        if idx < 2**32:
-            self.add_payload(pickle.LONG_BINPUT)
+        elif idx < 2**32:
+            self._append_opcode("LONG_BINPUT")
             self._add_number4(idx)
+        else:
+            self._append_opcode("PUT")
+            self._add_number(idx)
+            self._add_newline()
+
+        if not self._trace_state_valid:
             return
-        
-        self.add_payload(pickle.PUT)
-        self._add_number(idx)
-        self._add_newline()
+
+        if not self._stack:
+            self._invalidate_trace_state()
+            return
+
+        self._memo[idx] = self._stack[-1]
 
 
     # interfaces about payload
@@ -312,16 +375,19 @@ class Crafter:
 
     def clear(self):
         self._payload = b""
+        self._stack = []
+        self._memo = {}
+        self._trace_state_valid = True
         self._has_explicit_stop = False
 
 
     # utils for internal
     def _add_newline(self):
-        self.add_payload(b"\n")
+        self._append_payload(b"\n")
 
 
     def _add_number(self, n: int):
-        self.add_payload(str(n).encode())
+        self._append_payload(str(n).encode())
 
 
     def _add_number1(self, n: int):
@@ -337,7 +403,225 @@ class Crafter:
 
 
     def _add_number_to_bytes(self, n: int, length: int, *, signed=False):
-        self.add_payload(n.to_bytes(length, "little", signed=signed))
+        self._append_payload(n.to_bytes(length, "little", signed=signed))
+
+
+    def _invalidate_trace_state(self):
+        self._trace_state_valid = False
+
+
+    def _push_stack_value(self, value):
+        if not self._trace_state_valid:
+            return
+        self._stack.append(value)
+
+
+    def _pop_n(self, cnt: int):
+        if cnt < 0:
+            raise ValueError("count must not be negative")
+        if cnt == 0:
+            return []
+        if len(self._stack) < cnt:
+            raise IndexError("stack underflow")
+
+        values = self._stack[-cnt:]
+        del self._stack[-cnt:]
+        return values
+
+
+    def _pop_marked_items(self):
+        for idx in range(len(self._stack) - 1, -1, -1):
+            if self._stack[idx] == _STACK_MARK:
+                items = self._stack[idx + 1:]
+                del self._stack[idx:]
+                return items
+        raise ValueError("MARK is not found in the traced stack")
+
+
+    def _pop_marked_items_with_target(self):
+        items = self._pop_marked_items()
+        if not self._stack:
+            raise IndexError("stack underflow")
+        target = self._stack.pop()
+        return target, items
+
+
+    def _make_abstract_value(self, symbol):
+        name = getattr(symbol, "name", None)
+        if name == "tuple":
+            return _STACK_TUPLE
+        if name == "list":
+            return _STACK_LIST
+        if name == "dict":
+            return _STACK_DICT
+        if name == "set":
+            return _STACK_SET
+        if name == "frozenset":
+            return _STACK_FROZENSET
+        if name == "mark":
+            return _STACK_MARK
+        if name == "any":
+            return _STACK_ANY
+        return symbol
+
+
+    def _apply_opcode(self, op: pickletools.OpcodeInfo):
+        if not self._trace_state_valid:
+            return
+
+        try:
+            op_name = op.name
+
+            if op_name == "POP":
+                self._pop_n(1)
+                return
+
+            if op_name == "DUP":
+                self._push_stack_value(self._stack[-1])
+                return
+
+            if op_name == "MARK":
+                self._push_stack_value(_STACK_MARK)
+                return
+
+            if op_name == "NEWTRUE":
+                self._push_stack_value(True)
+                return
+
+            if op_name == "NEWFALSE":
+                self._push_stack_value(False)
+                return
+
+            if op_name == "NONE":
+                self._push_stack_value(None)
+                return
+
+            if op_name == "EMPTY_LIST":
+                self._push_stack_value([])
+                return
+
+            if op_name == "EMPTY_TUPLE":
+                self._push_stack_value(())
+                return
+
+            if op_name == "EMPTY_DICT":
+                self._push_stack_value({})
+                return
+
+            if op_name == "EMPTY_SET":
+                self._push_stack_value(set())
+                return
+
+            if op_name == "MEMOIZE":
+                if not self._stack:
+                    raise IndexError("stack underflow")
+                self._memo[len(self._memo)] = self._stack[-1]
+                return
+
+            if op_name == "TUPLE":
+                self._push_stack_value(tuple(self._pop_marked_items()))
+                return
+
+            if op_name in {"TUPLE1", "TUPLE2", "TUPLE3"}:
+                cnt = int(op_name[-1])
+                self._push_stack_value(tuple(self._pop_n(cnt)))
+                return
+
+            if op_name == "POP_MARK":
+                self._pop_marked_items()
+                return
+
+            if op_name == "APPEND":
+                target, item = self._pop_n(2)
+                if isinstance(target, list):
+                    target.append(item)
+                    self._push_stack_value(target)
+                else:
+                    self._push_stack_value(_STACK_LIST)
+                return
+
+            if op_name == "APPENDS":
+                target, items = self._pop_marked_items_with_target()
+                if isinstance(target, list):
+                    target.extend(items)
+                    self._push_stack_value(target)
+                else:
+                    self._push_stack_value(_STACK_LIST)
+                return
+
+            if op_name == "SETITEM":
+                target, key, value = self._pop_n(3)
+                if isinstance(target, dict):
+                    target[key] = value
+                    self._push_stack_value(target)
+                else:
+                    self._push_stack_value(_STACK_DICT)
+                return
+
+            if op_name == "SETITEMS":
+                target, items = self._pop_marked_items_with_target()
+                if len(items) % 2 != 0:
+                    raise ValueError("SETITEMS requires an even number of marked items")
+                if isinstance(target, dict):
+                    for idx in range(0, len(items), 2):
+                        target[items[idx]] = items[idx + 1]
+                    self._push_stack_value(target)
+                else:
+                    self._push_stack_value(_STACK_DICT)
+                return
+
+            if op_name == "ADDITEMS":
+                target, items = self._pop_marked_items_with_target()
+                if isinstance(target, set):
+                    target.update(items)
+                    self._push_stack_value(target)
+                else:
+                    self._push_stack_value(_STACK_SET)
+                return
+
+            if op_name == "LIST":
+                self._push_stack_value(list(self._pop_marked_items()))
+                return
+
+            if op_name == "DICT":
+                items = self._pop_marked_items()
+                if len(items) % 2 != 0:
+                    raise ValueError("DICT requires an even number of marked items")
+                d = {}
+                for idx in range(0, len(items), 2):
+                    d[items[idx]] = items[idx + 1]
+                self._push_stack_value(d)
+                return
+
+            if op_name == "FROZENSET":
+                self._push_stack_value(frozenset(self._pop_marked_items()))
+                return
+
+            if op_name == "STOP":
+                self._pop_n(1)
+                return
+
+            if op_name == "STACK_GLOBAL":
+                self._pop_n(2)
+                self._push_stack_value(_STACK_ANY)
+                return
+
+            if op_name == "REDUCE":
+                self._pop_n(2)
+                self._push_stack_value(_STACK_ANY)
+                return
+
+            if op_name == "BUILD":
+                self._pop_n(2)
+                self._push_stack_value(_STACK_ANY)
+                return
+
+            if op.stack_before:
+                self._pop_n(len(op.stack_before))
+            for symbol in op.stack_after:
+                self._push_stack_value(self._make_abstract_value(symbol))
+        except (IndexError, ValueError, TypeError):
+            self._invalidate_trace_state()
 
 
 # the payload has only ascii-printable characters
@@ -352,23 +636,26 @@ class AsciiCrafter(Crafter):
 
     # todo: rewrite some methods
     def push_bool(self, b: bool):
-        self.add_op("INT")
-        self.add_payload(b"01" if b else b"00")
+        self._append_opcode("INT")
+        self._append_payload(b"01" if b else b"00")
         self._add_newline()
+        self._push_stack_value(b)
 
 
     def push_int(self, n: int):
-        self.add_op("INT")
-        self.add_payload(str(n).encode())
+        self._append_opcode("INT")
+        self._append_payload(str(n).encode())
         self._add_newline()
+        self._push_stack_value(n)
 
 
     # not optimized
     def push_str(self, s: str):
-        self.add_op("STRING")
-        s = f"'{s}'"
-        self.add_payload(s.encode())
+        self._append_opcode("STRING")
+        encoded = f"'{s}'".encode()
+        self._append_payload(encoded)
         self._add_newline()
+        self._push_stack_value(s)
 
 
     # use_mark is ignored
@@ -389,30 +676,34 @@ class UnicodeCrafter(Crafter):
         length = len(data)
 
         if length < 0x100:
-            self.add_payload(pickle.SHORT_BINSTRING)
+            self._append_opcode("SHORT_BINSTRING")
             self._add_number1(length)
-            self.add_payload(data)
+            self._append_payload(data)
+            self._push_stack_value(s)
             return
         
         if length < 2**32:
-            self.add_payload(pickle.BINSTRING)
+            self._append_opcode("BINSTRING")
             self._add_number4(length)
-            self.add_payload(data)
+            self._append_payload(data)
+            self._push_stack_value(s)
             return
 
 
         # not tested
-        self.add_op("STRING")
-        self.add_payload(b"'")
-        self.add_payload(data)
-        self.add_payload(b"'")
+        self._append_opcode("STRING")
+        self._append_payload(b"'")
+        self._append_payload(data)
+        self._append_payload(b"'")
         self._add_newline()
+        self._push_stack_value(s)
 
 
     def stack_global(self):
         # u"\c293"
         self.put_memo(0xc2)  # no effect to stack
-        self.add_payload(pickle.STACK_GLOBAL)
+        self._append_opcode("STACK_GLOBAL")
+        self._apply_opcode(name_to_op["STACK_GLOBAL"])
 
 
     def import_from(self, module: str, name: str, *, use_stack=True):

--- a/tests/test_crafter_stack.py
+++ b/tests/test_crafter_stack.py
@@ -1,0 +1,105 @@
+import pickle
+import pickletools
+
+import pytest
+
+import pickaxe
+
+
+@pytest.mark.parametrize("crafter_cls", [pickaxe.Crafter, pickaxe.AsciiCrafter, pickaxe.UnicodeCrafter])
+def test_push_str_updates_traced_stack_exactly(crafter_cls):
+    crafter = crafter_cls()
+    crafter.push_str("stack")
+
+    assert crafter.stack_is_valid
+    assert crafter.stack == ["stack"]
+
+
+def test_to_tuple_tracks_exact_values():
+    crafter = pickaxe.Crafter()
+    crafter.push_int(7)
+    crafter.push_str("x")
+
+    crafter.to_tuple(2)
+
+    assert crafter.stack_is_valid
+    assert crafter.stack == [(7, "x")]
+
+
+def test_add_op_tracks_setitem_on_exact_dict():
+    crafter = pickaxe.Crafter()
+    crafter.empty_dict()
+    crafter.push_str("answer")
+    crafter.push_int(42)
+
+    crafter.add_op("SETITEM")
+
+    assert crafter.stack_is_valid
+    assert crafter.stack == [{"answer": 42}]
+    assert crafter.loads() == {"answer": 42}
+
+
+def test_memo_helpers_update_traced_state():
+    crafter = pickaxe.Crafter()
+    crafter.push_str("memo")
+    crafter.memoize()
+    crafter.get_memo(0)
+
+    assert crafter.stack_is_valid
+    assert crafter.memo_is_valid
+    assert crafter.memo == {0: "memo"}
+    assert crafter.stack == ["memo", "memo"]
+
+
+def test_add_payload_invalidates_traced_state():
+    crafter = pickaxe.Crafter()
+    crafter.push_bool(True)
+
+    crafter.add_payload(pickle.NEWFALSE)
+
+    assert not crafter.stack_is_valid
+    assert not crafter.memo_is_valid
+
+
+def test_add_op_with_argument_invalidates_traced_state():
+    crafter = pickaxe.Crafter()
+
+    crafter.add_op("PROTO")
+
+    assert crafter.payload == pickle.PROTO
+    assert not crafter.stack_is_valid
+
+
+def test_clear_resets_traced_state():
+    crafter = pickaxe.Crafter()
+    crafter.push_str("memo")
+    crafter.memoize()
+    crafter.add_payload(pickle.NEWFALSE)
+
+    crafter.clear()
+
+    assert crafter.payload == b""
+    assert crafter.stack == []
+    assert crafter.memo == {}
+    assert crafter.stack_is_valid
+    assert crafter.memo_is_valid
+
+
+def test_import_from_without_stack_keeps_abstract_trace():
+    crafter = pickaxe.Crafter()
+    crafter.import_from("builtins", "id", use_stack=False)
+
+    assert crafter.stack_is_valid
+    assert len(crafter.stack) == 1
+    assert isinstance(crafter.stack[-1], pickletools.StackObject)
+    assert crafter.stack[-1].name == "any"
+
+
+def test_unicode_stack_global_keeps_tracer_valid():
+    crafter = pickaxe.UnicodeCrafter()
+    crafter.import_from("os", "system")
+
+    assert crafter.stack_is_valid
+    assert len(crafter.stack) == 1
+    assert isinstance(crafter.stack[-1], pickletools.StackObject)
+    assert crafter.stack[-1].name == "any"


### PR DESCRIPTION
## Summary
- add traced stack and memo state to `Crafter`, with validity flags for raw byte paths that cannot be tracked safely
- keep high-level crafter helpers and subclass overrides on the tracked path so exact pushed values stay visible when possible
- add regression tests for exact stack values, memo tracing, invalidation, and subclass behavior

Closes #2.

## Testing
- `.venv/bin/pytest -q`
